### PR TITLE
add state reinitialization to reset function

### DIFF
--- a/engibench/problems/beams2d/v0.py
+++ b/engibench/problems/beams2d/v0.py
@@ -292,6 +292,7 @@ class Beams2D(Problem[npt.NDArray]):
             **kwargs: Additional keyword arguments.
         """
         super().reset(seed, **kwargs)
+        self.__st = State()
 
     def render(self, design: np.ndarray, *, open_window: bool = False) -> Any:
         """Renders the design in a human-readable format.


### PR DESCRIPTION
Please check and merge as needed. This simply allows for us to reset the problem state within a loop of simulating different beam designs. There was previously no way visible to the user to reset this state, leading to false simulated compliance after one loop iteration.

```
from engibench.utils.all_problems import BUILTIN_PROBLEMS
import numpy as np

problem_id: str = "beams2d"
seed: int = 1

problem = BUILTIN_PROBLEMS[problem_id]()

data = problem.dataset

train_ds = data["train"]
test_ds = data["test"]
val_ds = data["val"]

# Simulate all designs in the train, test, and validation datasets
dataset = test_ds
for i in range(len(dataset['optimal_design'])):
    problem.reset(seed=seed)
    result = problem.simulate(np.array(dataset['optimal_design'][i]), config = dataset.select_columns(problem.conditions_keys)[i])
    _, opt_history = problem.optimize(np.array(dataset['optimal_design'][i]), config = dataset.select_columns(problem.conditions_keys)[i])
    print("Dataset_Val: {:>10.2f}".format(dataset['c'][i]),
          "Re-Optimize_Val: {:>10.2f}".format(opt_history[-1].obj_values[0]),
          "Simulate_Val: {:>10.2f}".format(result[0]))
```