### PR TITLE
Fixed random_design function to pull from the dataset in the thermoelastic2d problem.

### DIFF
--- a/engibench/problems/thermoelastic2d/v0.py
+++ b/engibench/problems/thermoelastic2d/v0.py
@@ -218,16 +218,20 @@ class ThermoElastic2D(Problem[npt.NDArray]):
 
         return fig
 
-    def random_design(self) -> tuple[npt.NDArray, int]:
+    def random_design(self, dataset_split: str = "train", design_key: str = "optimal_design") -> tuple[npt.NDArray, int]:
         """Samples a valid random design.
 
+        Args:
+            dataset_split (str): The key for the dataset to sample from.
+            design_key (str): The key for the design to sample from.
+
         Returns:
-            DesignType: The valid random design.
+            Tuple of:
+                np.ndarray: The valid random design.
+                int: The random index selected.
         """
-        boundary_dict = dataclasses.asdict(self.conditions)
-        volfrac = boundary_dict["volfrac"]
-        design = volfrac * np.ones((NELX, NELY))
-        return design, 0
+        rnd = self.np_random.integers(low=0, high=len(self.dataset[dataset_split]), dtype=int)
+        return np.array(self.dataset[dataset_split][design_key][rnd]), rnd
 
 
 if __name__ == "__main__":
@@ -237,7 +241,7 @@ if __name__ == "__main__":
     # --- Load the problem dataset
     dataset = problem.dataset
     first_item = dataset["train"][0]
-    first_item_design = np.array(first_item["design"])
+    first_item_design = np.array(first_item["optimal_design"])
     problem.render(first_item_design, open_window=True)
 
     # --- Render the design


### PR DESCRIPTION
# Description

I modified the random_design method of the thermoelastic2d problem such that it returns a randomly sampled design in the dataset. Previously, it was just returning a randomly generated design with uniform density.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have run `ruff check .` and `ruff format`
- [x] I have run `mypy .`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


# Reviewer Checklist:

- [x] The content of this PR brings value to the community. It is not too specific to a particular use case.
- [ ] The tests and checks pass (linting, formatting, type checking). For a new problem, double check the github actions workflow to ensure the problem is being tested.
- [x] The documentation is updated.
- [x] The code is understandable and commented. No large code blocks are left unexplained, no huge file. Can I read and understand the code easily?
- [x] There is no merge conflict.
- [x] The changes are not breaking the existing results (datasets, training curves, etc.). If they do, is there a good reason for it? And is the associated problem version bumped?
- [ ] For a new problem, has the dataset been generated with our slurm script so we can re-generate it if needed? (This also ensures that the problem is running on the HPC.)
- [ ] For bugfixes, it is a robust fix and not a hacky workaround.
