### PR TITLE
Do not store final frame if using save_frame_interval > 0 for Photonics2D

### DIFF
--- a/engibench/problems/photonics2d/v0.py
+++ b/engibench/problems/photonics2d/v0.py
@@ -491,9 +491,10 @@ class Photonics2D(Problem[npt.NDArray]):
         )
         opti_steps_history.append(initial_design_optistep)
 
-        # Ensure directory exists for saving frames
-        frame_dir = "opt_frames"
-        os.makedirs(frame_dir, exist_ok=True)
+        if save_frame_interval is not None and save_frame_interval > 0:
+            # Ensure directory exists for saving frames
+            frame_dir = "opt_frames"
+            os.makedirs(frame_dir, exist_ok=True)
 
         # --- Define Objective Function for Ceviche Optimizer ---
         def objective_for_optimizer(rho_flat: npt.NDArray | ArrayBox) -> float | ArrayBox:
@@ -577,7 +578,7 @@ class Photonics2D(Problem[npt.NDArray]):
                 plt.close(fig)  # Close the figure to free memory
                 print(f"Callback Iter {iteration}: Saved frame to {save_path}")
             # --- End Frame Saving ---
-            if iteration == num_optimization_steps - 1:
+            if save_frame_interval is not None and save_frame_interval > 0 and iteration == num_optimization_steps - 1:
                 print(f"Final Iteration {iteration}: Objective Value: {last_scalar_obj_value:.3e}")
                 print("Saving render of final design...")
                 current_rho = rho_flat.reshape((num_elems_x, num_elems_y))
@@ -784,10 +785,13 @@ if __name__ == "__main__":
         print(f"First step objective: {opti_history[0].obj_values[0]:.4f}")
         print(f"Last step objective: {opti_history[-1].obj_values[0]:.4f}")
 
-    print("Rendering optimized design...")
-    fig_opt = problem.render(optimized_design, open_window=True)
-    frame_dir = "opt_frames"
-    fig_opt.savefig(frame_dir + "/optimized_design.png", dpi=200)
+    save_frame_interval = opt_config.get("save_frame_interval", 0)
+    if save_frame_interval is not None and save_frame_interval > 0:
+        print("Rendering optimized design...")
+        fig_opt = problem.render(optimized_design, open_window=True)
+        frame_dir = "opt_frames"
+        os.makedirs(frame_dir, exist_ok=True)
+        fig_opt.savefig(frame_dir + "/optimized_design.png", dpi=200)
 
     print("Simulating the final optimized design...")
     # Simulate returns the raw objective = penalty - overlap1*overlap2


### PR DESCRIPTION
# Description

This PR makes saving the final frame for the Photonics2D problem optional.

Fixes #212 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [X] I have run `ruff check .` and `ruff format`
- [X] I have run `mypy .`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

P.S. There are still mypy errors related to other problems (airfoil and thermoelastic2D) as described [here](https://github.com/IDEALLab/EngiBench/pull/209#issuecomment-3724131126) which I think should be fixed.

@markfuge I can not assign you directly as reviewer as I am not an official developer of the project.

# Reviewer Checklist:

- [x] The content of this PR brings value to the community. It is not too specific to a particular use case.
- [x] The tests and checks pass (linting, formatting, type checking). For a new problem, double check the github actions workflow to ensure the problem is being tested.
- [ ] The documentation is updated.
- [x] The code is understandable and commented. No large code blocks are left unexplained, no huge file. Can I read and understand the code easily?
- [x] There is no merge conflict.
- [x] The changes are not breaking the existing results (datasets, training curves, etc.). If they do, is there a good reason for it? And is the associated problem version bumped?
- [ ] For a new problem, has the dataset been generated with our slurm script so we can re-generate it if needed? (This also ensures that the problem is running on the HPC.)
- [x] For bugfixes, it is a robust fix and not a hacky workaround.
