### PR TITLE
fix(photonics2d): provide default value for num_optimization_steps

### DIFF
--- a/engibench/problems/photonics2d/v0.py
+++ b/engibench/problems/photonics2d/v0.py
@@ -133,6 +133,7 @@ class Photonics2D(Problem[npt.NDArray]):
 
     dataset_id = f"IDEALLab/photonics_2d_{Config.num_elems_x}_{Config.num_elems_y}_v0"
     container_id = None
+    config: Config
 
     def __init__(
         self,
@@ -173,7 +174,7 @@ class Photonics2D(Problem[npt.NDArray]):
     def _setup_simulation(self, config: dict[str, Any] | None = None) -> dict[str, Any]:
         """Helper function to setup simulation parameters and domain."""
         # Merge config with default conditions
-        current_conditions = {**dataclasses.asdict(self.conditions), **(config or {})}
+        current_conditions = {**dataclasses.asdict(self.config), **(config or {})}
 
         # Initialize domain geometry
         self._bg_rho, self._design_region, self._input_slice, self._output_slice1, self._output_slice2 = init_domain(


### PR DESCRIPTION
# Description

Fixes #224

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have run `ruff check .` and `ruff format`
- [x] I have run `mypy .`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->


# Reviewer Checklist:

- [x] The content of this PR brings value to the community. It is not too specific to a particular use case.
- [x] The tests and checks pass (linting, formatting, type checking). For a new problem, double check the github actions workflow to ensure the problem is being tested.
- [ ] The documentation is updated.
- [x] The code is understandable and commented. No large code blocks are left unexplained, no huge file. Can I read and understand the code easily?
- [x] There is no merge conflict.
- [x] The changes are not breaking the existing results (datasets, training curves, etc.). If they do, is there a good reason for it? And is the associated problem version bumped?
- [ ] For a new problem, has the dataset been generated with our slurm script so we can re-generate it if needed? (This also ensures that the problem is running on the HPC.)
- [x] For bugfixes, it is a robust fix and not a hacky workaround.
