### PR TITLE
Bump GitHub actions Node24

### DIFF
--- a/.github/workflows/docs-main.yml
+++ b/.github/workflows/docs-main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Remove .doctrees
         run: rm -r _build/.doctrees
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: docs
           path: _build
@@ -73,7 +73,7 @@ jobs:
       SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           name: docs
           path: _build

--- a/.github/workflows/docs-main.yml
+++ b/.github/workflows/docs-main.yml
@@ -15,9 +15,9 @@ jobs:
     name: Run doctests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -33,12 +33,12 @@ jobs:
     name: Generate Latest Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fetch all tags
         run: git fetch --tags
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -59,7 +59,7 @@ jobs:
       - name: Remove .doctrees
         run: rm -r _build/.doctrees
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: docs
           path: _build
@@ -72,8 +72,8 @@ jobs:
     env:
       SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v5
         with:
           name: docs
           path: _build

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -15,12 +15,12 @@ jobs:
     env:
       SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fetch all tags
         run: git fetch --tags
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v3
       - run: ruff check
       - run: ruff format --check
@@ -19,9 +19,9 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: pip install mypy numpy pytest
       - run: mypy

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,8 +14,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.1
 
   conventional-commits:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history needed for commit comparison
 

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 
@@ -30,7 +30,7 @@ jobs:
     - name: Build wheels and a source tarball
       run: pyproject-build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         path: dist
 
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Download dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: artifact
         path: dist

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Build wheels and a source tarball
       run: pyproject-build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         path: dist
 
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Download dists
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: artifact
         path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install ngspice
@@ -40,9 +40,9 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -74,9 +74,9 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install ngspice

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install ngspice
@@ -40,9 +40,9 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -74,9 +74,9 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     # - name: Install ngspice


### PR DESCRIPTION
# Description

- Bump all GitHub Actions to their latest major versions to resolve Node.js 20 deprecation warnings
- Node.js 20 will be forced off GitHub Actions runners on **June 2, 2026** and fully removed on **September 16, 2026** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/))

### Version bumps

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v4/v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |

`pre-commit/action` remains at v3.0.1 as it is the latest release. It internally uses `actions/cache@v4` (Node.js 20), with no plan to update in the future:  https://github.com/pre-commit/action/issues/241. 

### Affected workflows
- `lint.yaml`
- `pre-commit.yaml`
- `test.yml`
- `docs-main.yml`
- `docs-release.yml`
- `publish-pypi.yaml`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [X] I have run `ruff check .` and `ruff format`
- [X] I have run `mypy .`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Reviewer Checklist:

- [ ] The content of this PR brings value to the community. It is not too specific to a particular use case.
- [ ] The tests and checks pass (linting, formatting, type checking). For a new problem, double check the github actions workflow to ensure the problem is being tested.
- [ ] The documentation is updated.
- [ ] The code is understandable and commented. No large code blocks are left unexplained, no huge file. Can I read and understand the code easily?
- [ ] There is no merge conflict.
- [ ] The changes are not breaking the existing results (datasets, training curves, etc.). If they do, is there a good reason for it? And is the associated problem version bumped?
- [ ] For a new problem, has the dataset been generated with our slurm script so we can re-generate it if needed? (This also ensures that the problem is running on the HPC.)
- [ ] For bugfixes, it is a robust fix and not a hacky workaround.