### PR TITLE
docs(beams2D): adapt readme and tutorial to use v1 for Beams2D + problem name consistency + list of problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install "engibench[all]"
 
 <!-- start api -->
 ```python
-from engibench.problems.beams2d.v0 import Beams2D
+from engibench.problems.beams2d.v1 import Beams2D
 
 # Create a problem
 problem = Beams2D(seed=0)

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,7 @@ introduction/api
 
 problems/airfoil
 problems/beams2d
-problems/thermoelastic2d
-problems/thermoelastic3d
+problems/thermoelastic
 problems/photonics2d
 problems/power_electronics
 problems/heatconduction

--- a/docs/introduction/basic_usage.md
+++ b/docs/introduction/basic_usage.md
@@ -3,7 +3,7 @@
 Our API is designed to be simple and easy to use. Here is a basic example of how to use EngiBench to create a problem, get the dataset, and evaluate a design.
 
 ```python
-from engibench.problems.beams2d.v0 import Beams2D
+from engibench.problems.beams2d.v1 import Beams2D
 
 # Create a problem
 problem = Beams2D(seed=0)

--- a/docs/problems/heatconduction.md
+++ b/docs/problems/heatconduction.md
@@ -1,4 +1,4 @@
-# Heat Conduction
+# HeatConduction
 
 These problems represent typical topology optimization problems where the goal is to decide where to place material in the design domain.
 
@@ -13,8 +13,8 @@ These problems represent typical topology optimization problems where the goal i
 
 
 We provide two versions for this problem:
-- [Heat Conduction 2D](./heatconduction2d.md) In this problem, we optimize a 2D slice of an object.
-- [Heat Conduction 3D](./heatconduction3d.md) This version is heavier, we optimize a 3D object.
+- [HeatConduction2D](./heatconduction2d.md) In this problem, we optimize a 2D slice of an object.
+- [HeatConduction3D](./heatconduction3d.md) This version is heavier, we optimize a 3D object.
 
 ```{toctree}
 :hidden:

--- a/docs/problems/heatconduction2d.md
+++ b/docs/problems/heatconduction2d.md
@@ -1,4 +1,4 @@
-# Heat Conduction 2D
+# HeatConduction2D
 
 ``` {problem:table}
 :lead: Milad Habibi @MIladHB

--- a/docs/problems/heatconduction3d.md
+++ b/docs/problems/heatconduction3d.md
@@ -1,4 +1,4 @@
-# Heat Conduction 3D
+# HeatConduction3D
 
 ``` {problem:table}
 :lead: Milad Habibi @MIladHB

--- a/docs/problems/thermoelastic.md
+++ b/docs/problems/thermoelastic.md
@@ -1,0 +1,24 @@
+# Thermoelastic
+
+These problems represent multi-physics topology optimization problems that capture the coupling between structural and thermal domains.
+
+
+<div style="margin-left: 300px; display: flex; justify-content: center; gap: 20px; flex-direction: column; align-items: center;">
+    <div style="display: flex; justify-content: center; gap: 20px;">
+        <img src="../../_static/img/problems/thermoelastic2d.png" alt="Thermoelastic 2D problem setup" width="400"/>
+        <img src="../../_static/img/problems/thermoelastic3d.png" alt="Thermoelastic 3D problem setup" width="400"/>
+    </div>
+    <div style="text-align: center;">Left: 2D version, Right: 3D version</div>
+</div>
+
+
+We provide two versions for this problem:
+- [Thermoelastic2D](./thermoelastic2d.md) A 2D multi-physics topology optimization problem.
+- [Thermoelastic3D](./thermoelastic3d.md) The 3D extension of the thermoelastic problem.
+
+```{toctree}
+:hidden:
+
+./thermoelastic2d
+./thermoelastic3d
+```

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from engibench.problems.beams2d.v0 import Beams2D"
+    "from engibench.problems.beams2d.v1 import Beams2D"
    ]
   },
   {


### PR DESCRIPTION
# Description

Adapt the README and tutorial notebook to use v1 instead of v0 for the Beams2D problem.
Additionally make the name of the problems consistent with EngiBench paper (no space) and improve the list of problems in the documentation. 

## Type of change

- [X] Documentation only change (no code changed)

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [X] I have run `ruff check .` and `ruff format`
- [X] I have run `mypy .`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# Reviewer Checklist:

- [x] The content of this PR brings value to the community. It is not too specific to a particular use case.
- [x] The tests and checks pass (linting, formatting, type checking). For a new problem, double check the github actions workflow to ensure the problem is being tested.
- [x] The documentation is updated.
- [x] The code is understandable and commented. No large code blocks are left unexplained, no huge file. Can I read and understand the code easily?
- [x] There is no merge conflict.
- [x] The changes are not breaking the existing results (datasets, training curves, etc.). If they do, is there a good reason for it? And is the associated problem version bumped?
- [ ] For a new problem, has the dataset been generated with our slurm script so we can re-generate it if needed? (This also ensures that the problem is running on the HPC.)
- [ ] For bugfixes, it is a robust fix and not a hacky workaround.