### PR TITLE
fix(thermoelastic3d): import napari lazily 

### DIFF
--- a/engibench/problems/thermoelastic3d/model/fem_plotting.py
+++ b/engibench/problems/thermoelastic3d/model/fem_plotting.py
@@ -1,6 +1,5 @@
 """Module for plotting a 3D thermoelastic design with napari."""
 
-import napari
 import numpy as np
 
 
@@ -19,6 +18,8 @@ def plot_fem_3d(bcs, design) -> None:
     Returns:
         None
     """
+    import napari  # noqa: PLC0415 -- lazy import: optional dependency, only needed for plotting
+
     fixed_elements = bcs.get("fixed_elements", np.zeros_like(design))
 
     force_elements_x = bcs.get("force_elements_x", np.zeros_like(design))

--- a/engibench/problems/thermoelastic3d/v0.py
+++ b/engibench/problems/thermoelastic3d/v0.py
@@ -6,7 +6,6 @@ from dataclasses import field
 from typing import Annotated, Any
 
 from gymnasium import spaces
-import napari
 import numpy as np
 import numpy.typing as npt
 
@@ -187,6 +186,8 @@ class ThermoElastic3D(Problem[npt.NDArray]):
         Returns:
             fig (np.ndarray): The rendered design.
         """
+        import napari  # noqa: PLC0415 -- lazy import: optional dependency, only needed for rendering
+
         design = np.array(design)
         design = np.transpose(design, (2, 0, 1))
 


### PR DESCRIPTION
# Description

`thermoelastic3d/v0.py` and `thermoelastic3d/model/fem_plotting.py` imported `napari` at module
top level. Since `napari` is an optional dependency (declared under the `thermoelastic3d`/`all`
extras and used only for 3D rendering), importing the problem — and therefore collecting
`tests/test_problem_implementations.py`. Fails with `ModuleNotFoundError: No module named 'napari'`
in any environment without napari installed.

Fix: import `napari` lazily inside the render/plot functions that use it. The module now imports
without napari present; napari is only required when actually rendering. No behavior change when
napari is installed.

Fixes # (no tracked issue; create one if desired)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

N/A.

# Checklist:

- [x] I have run the `pre-commit` checks with `pre-commit run --all-files`
- [x] I have run `ruff check .` and `ruff format`
- [x] I have run `mypy .`
- [x] I have commented my code, particularly in hard-to-understand areas (each lazy import carries a `# noqa: PLC0415` comment explaining why)
- [ ] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — no new test added, but `test_problem_implementations.py` now *collects and passes* without napari, which previously errored
- [x] New and existing unit tests pass locally with my changes (thermoelastic3d problem tests pass; collection succeeds without napari)

# Reviewer Checklist (pre-assessed — confirm during review):

- [x] Brings value / not too specific — optional dep no longer breaks import/collection
- [x] Tests/checks pass (lint, format, type)
- [ ] Documentation updated — N/A
- [x] Code understandable and commented
- [x] No merge conflict (branch cleanly off latest `main`)
- [x] Not breaking existing results; no version bump needed (lazy import only)
- [ ] New-problem dataset via slurm — N/A
- [x] Robust fix, not a hacky workaround (standard lazy-import pattern for optional deps)