### PR TITLE
docs: move dataset generation guide to introduction

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ lastpage:
 
 introduction/install
 introduction/basic_usage
+Data Generation (Slurm) <introduction/dataset_generation_slurm>
 introduction/api
 ```
 

--- a/docs/introduction/dataset_generation_slurm.md
+++ b/docs/introduction/dataset_generation_slurm.md
@@ -1,0 +1,79 @@
+# Dataset Generation via Slurm
+
+EngiBench ships ready-to-use datasets for most workflows. When you need to generate additional simulation or optimization samples, use a problem-provided dataset-generation entry point and submit it through your HPC cluster's Slurm scheduler. This page shows the end-to-end pattern with the Airfoil dataset-generation script; for the lower-level callback API, see the [Slurm utilities](../utils/slurm.md).
+
+## When to use this workflow
+
+Use this workflow when you need to create new samples rather than only loading the published Hugging Face dataset through `problem.dataset`. The exact entry point and command-line arguments are problem-specific, but the overall pattern is:
+
+1. write a small shell script with the cluster resources and environment setup;
+2. activate an environment with EngiBench installed;
+3. call the problem's dataset-generation Python script; and
+4. submit the shell script with `sbatch`.
+
+## Airfoil example submission script
+
+The Airfoil problem includes a dataset-generation entry point at [`engibench/problems/airfoil/dataset_slurm_airfoil.py`](source:engibench/problems/airfoil/dataset_slurm_airfoil.py). The script below submits a small simulation dataset-generation run. Save it as `dataset_slurm_airfoil.sh` and adjust paths, module names, and resource settings for your cluster.
+
+```bash
+#!/bin/bash
+#SBATCH -t 01:00:00
+#SBATCH -n 1
+#SBATCH -c 1
+
+export OMP_NUM_THREADS=1
+
+# Apptainer image cache. Using $HOME keeps the script portable across clusters.
+export APPTAINER_HOME=$HOME/scratch/EngiBench
+export APPTAINER_CACHEDIR=$APPTAINER_HOME/apptainer-cache
+
+# Load the Apptainer module if your cluster requires it. For example, this is
+# not required on ETH's Euler cluster, where Apptainer is available by default
+# and no such module exists.
+module load apptainer
+
+# Activate a preconfigured Python environment with EngiBench installed.
+# Adjust the path to your virtual environment. The convention used by `uv` and
+# most Python tooling is `.venv`; this example assumes the virtual environment
+# lives in the parent directory.
+source ../.venv/bin/activate
+
+# Run the dataset-generation Python file. The CLI exposes many parameters of
+# the dataset generation, including the number of LHS samples and the Mach,
+# Reynolds, and angle-of-attack ranges. Further customization, such as changing
+# the sampling strategy or algorithm, requires editing the Python file.
+python ../engibench/problems/airfoil/dataset_slurm_airfoil.py \
+    -type simulate \
+    -account "$SLURM_JOB_ACCOUNT" \
+    -n_designs 5 \
+    -n_flows 1 \
+    -group_size 1 \
+    -minutes_per_sim 5 \
+    -n_slurm_array 1000 \
+    -min_ma 0.25 \
+    -max_ma 0.75 \
+    -min_re 1.0e6 \
+    -max_re 1.0e7 \
+    -min_aoa 0.0 \
+    -max_aoa 10.0 \
+    --field_output
+```
+
+## Submit the job
+
+Submit the script, passing your Slurm account on the command line:
+
+```bash
+sbatch -A <your-account> dataset_slurm_airfoil.sh
+```
+
+The account is exposed inside the job via `$SLURM_JOB_ACCOUNT` and forwarded to `dataset_slurm_airfoil.py` through the `-account` flag. The dataset-generation script uses that account for the worker array jobs it spawns internally.
+
+## Cluster-specific settings
+
+Before running a large dataset-generation job, check your cluster's Slurm policy and start with a small test run. In particular:
+
+- adjust the `module load apptainer` line to match your cluster, or remove it if Apptainer is available by default;
+- adjust the virtual environment path so the job activates the environment where EngiBench is installed;
+- start with small values for `-n_designs`, `-n_flows`, `-group_size`, and `-minutes_per_sim`; and
+- keep `-n_slurm_array` within the job-array limit recommended by your cluster.

--- a/docs/introduction/dataset_generation_slurm.md
+++ b/docs/introduction/dataset_generation_slurm.md
@@ -55,8 +55,7 @@ python ../engibench/problems/airfoil/dataset_slurm_airfoil.py \
     -min_re 1.0e6 \
     -max_re 1.0e7 \
     -min_aoa 0.0 \
-    -max_aoa 10.0 \
-    --field_output
+    -max_aoa 10.0
 ```
 
 ## Submit the job

--- a/docs/utils/slurm.md
+++ b/docs/utils/slurm.md
@@ -1,7 +1,10 @@
-# Parameter space discovery via slurm
+# Parameter space discovery via Slurm
 
 This module allows submitting a python callback as a slurm job array where each
 individual job runs the callback with a different set of parameters.
+
+For an end-to-end problem-specific dataset-generation script submitted via
+Slurm, see [Dataset Generation via Slurm](../introduction/dataset_generation_slurm.md).
 
 ```{testsetup} slurm
 import numpy as np
@@ -158,64 +161,3 @@ To tweak the arguments passed to sbatch, the `config` argument can be passed to 
 .. autoclass:: engibench.utils.slurm.JobError
    :members:
 ```
-
-## Example: Airfoil dataset generation submission script
-
-Problems that ship with their own dataset-generation entry point (e.g.,
-`engibench/problems/airfoil/dataset_slurm_airfoil.py`) are launched with a
-thin bash wrapper submitted via `sbatch`. An example for the airfoil problem:
-
-```bash
-#!/bin/bash
-#SBATCH -t 01:00:00
-#SBATCH -n 1
-#SBATCH -c 1
-
-export OMP_NUM_THREADS=1
-
-# Apptainer image cache. Using $HOME keeps the script portable across clusters.
-export APPTAINER_HOME=$HOME/scratch/EngiBench
-export APPTAINER_CACHEDIR=$APPTAINER_HOME/apptainer-cache
-
-# Load the apptainer module. Note that not all HPC systems require this
-# and/or the module name may differ. For example, not required on ETH's Euler cluster,
-# where apptainer is available by default and no such module exists.
-module load apptainer
-
-# Activate a preconfigured Python environment with EngiBench installed.
-# Adjust the path to your venv. The convention used by `uv` and most
-# Python tooling is `.venv`; this example assumes the virtual environment
-# lives in the parent directory.
-source ../.venv/bin/activate
-
-# Run the dataset generaiton python file. Note that the CLI exposes
-# many parameters of the dataset generation, e.g. number of LHS samples
-# and Mach, Reynolds, and alpha ranges. However, further customization,
-# e.g. changing the sampling strategy and algorithm, will require
-# editing of the python file.
-python ../engibench/problems/airfoil/dataset_slurm_airfoil.py \
-    -type simulate \
-    -account "$SLURM_JOB_ACCOUNT" \
-    -n_designs 5 \
-    -n_flows 1 \
-    -group_size 1 \
-    -minutes_per_sim 5 \
-    -n_slurm_array 1000 \
-    -min_ma 0.25 \
-    -max_ma 0.75 \
-    -min_re 1.0e6 \
-    -max_re 1.0e7 \
-    -min_aoa 0.0 \
-    -max_aoa 10.0 \
-    --field_output
-```
-
-Submit the script, passing your SLURM account on the command line:
-
-```bash
-sbatch -A <your-account> dataset_slurm_airfoil.sh
-```
-
-The account is exposed inside the job via `$SLURM_JOB_ACCOUNT` and is
-forwarded to `dataset_slurm_airfoil.py` through the `-account` flag, which
-uses it to charge the worker array jobs the script spawns internally.

--- a/engibench/utils/slurm/__init__.py
+++ b/engibench/utils/slurm/__init__.py
@@ -123,7 +123,7 @@ class SubmittedJobArray(Generic[R]):
 
         To prevent larger workloads running on a login node, this function will raise an exception if the resulting list in pickled
         form takes more than `size_limit` bytes (recommendation: 10MB).
-        Only increase / set to 0 if you want to annoy the HPC team 😈.
+        Only increase this limit, or set it to 0, if you understand the impact on the login node and your cluster policy allows it.
         - :attr:`f_reduce` - The callable which performs the post processing on the list of return values for each job.
         - :attr:`slurm_args` - Arguments passed to `sbatch`.
         - :attr:`size_limit` - Upper limit for the allowed size of the post processed data in pickled form.

--- a/engibench/utils/slurm/__init__.py
+++ b/engibench/utils/slurm/__init__.py
@@ -123,7 +123,9 @@ class SubmittedJobArray(Generic[R]):
 
         To prevent larger workloads running on a login node, this function will raise an exception if the resulting list in pickled
         form takes more than `size_limit` bytes (recommendation: 10MB).
-        Only increase this limit, or set it to 0, if you understand the impact on the login node and your cluster policy allows it.
+        Only increase this limit, or set it to ``None`` to disable the check, if you understand the impact on the login node
+        and your cluster policy allows it.
+
         - :attr:`f_reduce` - The callable which performs the post processing on the list of return values for each job.
         - :attr:`slurm_args` - Arguments passed to `sbatch`.
         - :attr:`size_limit` - Upper limit for the allowed size of the post processed data in pickled form.

--- a/tests/tools/fake_sbatch.py
+++ b/tests/tools/fake_sbatch.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import argparse
 import shlex


### PR DESCRIPTION
## Summary
- Move the Airfoil dataset generation submission script into a new Introduction page
- Use a shorter sidebar label: Data Generation (Slurm)
- Link from the generic Slurm utilities page to the new guide
- Replace informal HPC-team wording with a cluster-policy warning

## Screenshot
![Updated Data Generation (Slurm) docs page](https://raw.githubusercontent.com/IDEALLab/EngiBench/0750a93/.github/pr-assets/pr-263-dataset-generation-slurm.png)

## Validation
- uv run python -m sphinx -E -b dirhtml docs docs/_build/dirhtml
- uv run python -m sphinx -b doctest docs docs/_build/doctest
- uvx pre-commit run --files docs/index.md docs/introduction/dataset_generation_slurm.md docs/utils/slurm.md engibench/utils/slurm/__init__.py tests/tools/fake_sbatch.py

Addresses #261
