### PR TITLE
fix "Thermoelastic3D: sensitivity filter averages the wrong elements when nelx ≠ nely"

### DIFF
--- a/engibench/problems/thermoelastic3d/model/fem_model.py
+++ b/engibench/problems/thermoelastic3d/model/fem_model.py
@@ -95,7 +95,7 @@ class FeaModel3D:
             Returns:
                 g_idx (int): The global index of an element.
             """
-            return (nely * nelz) * ix + (nelz) * iy + iz
+            return (iy * nelx + ix) * nelz + iz
 
         i_h: list[int] = []
         j_h: list[int] = []

--- a/tests/test_thermoelastic3d.py
+++ b/tests/test_thermoelastic3d.py
@@ -1,6 +1,9 @@
+import numpy as np
+import numpy.typing as npt
 import pytest
 
 from engibench.problems.thermoelastic3d import ThermoElastic3D
+from engibench.problems.thermoelastic3d.model.fem_model import FeaModel3D
 
 
 def test_thermoelastic3d_config_builds_matching_non_cubic_default_masks() -> None:
@@ -22,3 +25,19 @@ def test_thermoelastic3d_unsupported_dataset_configs_fail_before_loading() -> No
         _ = problem.dataset
     with pytest.raises(ValueError, match="dataset access is implemented only for cubic grids"):
         problem.random_design()
+
+
+def reference_cone(nely: int, nelx: int, nelz: int, rmin: float) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """The correct cone filter on the (nely, nelx, nelz) grid the design actually uses."""
+    coords = np.array([(y, x, z) for y in range(nely) for x in range(nelx) for z in range(nelz)], float)
+    dist = np.linalg.norm(coords[:, None, :] - coords[None, :, :], axis=-1)
+    h = np.maximum(0.0, rmin - dist)
+    return h, h.sum(axis=1)
+
+
+def test_filter_matches_reference_on_non_cubic_grid() -> None:
+    nely, nelx, nelz, rmin = 4, 2, 3, 1.5
+    h, hs = FeaModel3D().get_filter(nelx, nely, nelz, rmin)
+    rh, rhs = reference_cone(nely, nelx, nelz, rmin)
+    v = np.arange(nely * nelx * nelz)
+    np.testing.assert_allclose((h @ v) / hs, (rh @ v) / rhs, rtol=1e-12)


### PR DESCRIPTION
# Description

Swap nelx <-> nely in `thermoelastic3d.model.fem_model.FeaModel3D.get_filter()`

Fixes #255

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have run `ruff check .` and `ruff format`
- [ ] I have run `mypy .`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->


# Reviewer Checklist:

- [ ] The content of this PR brings value to the community. It is not too specific to a particular use case.
- [ ] The tests and checks pass (linting, formatting, type checking). For a new problem, double check the github actions workflow to ensure the problem is being tested.
- [ ] The documentation is updated.
- [ ] The code is understandable and commented. No large code blocks are left unexplained, no huge file. Can I read and understand the code easily?
- [ ] There is no merge conflict.
- [ ] The changes are not breaking the existing results (datasets, training curves, etc.). If they do, is there a good reason for it? And is the associated problem version bumped?
- [ ] For a new problem, has the dataset been generated with our slurm script so we can re-generate it if needed? (This also ensures that the problem is running on the HPC.)
- [ ] For bugfixes, it is a robust fix and not a hacky workaround.
