### PR TITLE
fix(power-electronics): restore reproducible ngspice on macOS

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v4.0.0
-        with:
-          version: "0.15.21"
       - run: ruff check
       - run: ruff format --check
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/ruff-action@v4.0.0
+        with:
+          version: "0.15.21"
       - run: ruff check
       - run: ruff format --check
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         pytest -s
 
   macos-test:
-    runs-on: macos-15
+    runs-on: macos-15-intel
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         pytest -s
 
   macos-test:
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     strategy:
       matrix:
@@ -79,17 +79,20 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    # - name: Install ngspice
-    #   run: |
-    #      # for power electronics problems
-    #      VERSION=45.2
-    #      brew tap-new local/oldies
-    #      brew extract --version=$VERSION ngspice local/oldies
-    #      # Fix outdated URL:
-    #      sed -i -e "s|ng-spice-rework/|ng-spice-rework/old-releases/|" /opt/homebrew/Library/Taps/local/homebrew-oldies/Formula/ngspice@${VERSION}.rb
-    #      brew install local/oldies/ngspice@$VERSION
-    #      brew pin ngspice@$VERSION
-    #      ngspice --version
+    - name: Cache ngspice 44.2
+      id: cache-ngspice
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/engibench/ngspice-44.2
+        key: ngspice-44.2-${{ runner.os }}-${{ runner.arch }}-v1
+    - name: Build ngspice 44.2
+      if: steps.cache-ngspice.outputs.cache-hit != 'true'
+      run: scripts/install_ngspice_macos.sh "$HOME/.cache/engibench/ngspice-44.2"
+    - name: Configure ngspice
+      run: |
+        NGSPICE="$HOME/.cache/engibench/ngspice-44.2/bin/ngspice"
+        echo "NGSPICE_PATH=$NGSPICE" >> "$GITHUB_ENV"
+        "$NGSPICE" --version
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/engibench/problems/power_electronics/README.md
+++ b/engibench/problems/power_electronics/README.md
@@ -29,6 +29,10 @@ scripts/install_ngspice_macos.sh "$HOME/.local/ngspice-44.2"
 export NGSPICE_PATH="$HOME/.local/ngspice-44.2/bin/ngspice"
 ```
 
+The installer builds the validated x86_64 binary. On Apple Silicon, it runs
+through Rosetta 2 so that simulation results remain consistent with the
+EngiBench reference values.
+
 On every platform, an explicit `PowerElectronics(ngspice_path=...)` argument
 takes precedence over `NGSPICE_PATH`, which takes precedence over `PATH`.
 

--- a/engibench/problems/power_electronics/README.md
+++ b/engibench/problems/power_electronics/README.md
@@ -33,6 +33,11 @@ The installer builds the validated x86_64 binary. On Apple Silicon, it runs
 through Rosetta 2 so that simulation results remain consistent with the
 EngiBench reference values.
 
+Architecture-dependent transient results have also been reported in the
+[ngspice issue tracker](https://sourceforge.net/p/ngspice/bugs/622/). That
+report concerns a different circuit, but documents significant AArch64 and
+x86_64 differences in a numerically sensitive simulation.
+
 On every platform, an explicit `PowerElectronics(ngspice_path=...)` argument
 takes precedence over `NGSPICE_PATH`, which takes precedence over `PATH`.
 

--- a/engibench/problems/power_electronics/README.md
+++ b/engibench/problems/power_electronics/README.md
@@ -19,8 +19,18 @@ Available in Ubuntu 20, 22 and 24.
 
 Note: ``pip install`` won't work.
 
-### 3. MacOS
-`brew install ngspice`
+### 3. macOS
+
+EngiBench supports ngspice versions 42 through 45. Current Homebrew releases
+may be newer, so you can build the pinned CI version instead:
+
+```bash
+scripts/install_ngspice_macos.sh "$HOME/.local/ngspice-44.2"
+export NGSPICE_PATH="$HOME/.local/ngspice-44.2/bin/ngspice"
+```
+
+On every platform, an explicit `PowerElectronics(ngspice_path=...)` argument
+takes precedence over `NGSPICE_PATH`, which takes precedence over `PATH`.
 
 ## Example circuit graph
 ![5_4_3_6_10-dcdc_converter_1](../../../docs/_static/img/problems/power_electronics.png)
@@ -74,7 +84,7 @@ There is no condition for this problem.
 ### Simulator
 The simulator is ngSpice circuit simulator. You can download it based on your operating system:
 - Windows: https://sourceforge.net/projects/ngspice/files/ng-spice-rework/44.2/
-- MacOS: `brew install ngspice`
+- macOS: use `scripts/install_ngspice_macos.sh` and set `NGSPICE_PATH`
 - Linux: `sudo apt-get install ngspice`
 
 ### Dataset

--- a/engibench/problems/power_electronics/utils/ngspice.py
+++ b/engibench/problems/power_electronics/utils/ngspice.py
@@ -8,18 +8,29 @@ import subprocess
 
 MIN_SUPPORTED_VERSION: int = 42  # Major version number of ngspice
 MAX_SUPPORTED_VERSION: int = 45  # Major version number of ngspice
+NGSPICE_PATH_ENV = "NGSPICE_PATH"
 
 
 class NgSpice:
     """A class to handle ngspice execution across different operating systems."""
 
-    def __init__(self, ngspice_windows_path: str | None = None) -> None:
+    def __init__(
+        self,
+        ngspice_path: str | None = None,
+        *,
+        ngspice_windows_path: str | None = None,
+    ) -> None:
         """Initialize the NgSpice wrapper.
 
         Args:
-            ngspice_windows_path: The path to the ngspice executable for Windows.
+            ngspice_path: Path to the ngspice executable on any supported platform.
+                Takes precedence over ``NGSPICE_PATH`` and ``PATH``.
+            ngspice_windows_path: Deprecated alias for ``ngspice_path``.
         """
-        self.ngspice_windows_path = os.path.normpath(ngspice_windows_path) if ngspice_windows_path else None
+        if ngspice_path is not None and ngspice_windows_path is not None:
+            raise ValueError("Pass either ngspice_path or ngspice_windows_path, not both.")
+
+        self.configured_path = ngspice_path or ngspice_windows_path or os.environ.get(NGSPICE_PATH_ENV)
         self.system = platform.system().lower()
         self._ngspice_path = self._get_ngspice_path()
         if not MIN_SUPPORTED_VERSION <= self.version <= MAX_SUPPORTED_VERSION:
@@ -31,40 +42,33 @@ class NgSpice:
         Returns:
             The path to the ngspice executable
         """
-        if self.system == "windows":
-            # For Windows, use the bundled ngspice.exe
-            # Look for ngspice in PATH (e.g. Chocolatey), Spice64 folder and common install locations
-            possible_paths = [
-                self.ngspice_windows_path,
-                shutil.which("ngspice"),
-                os.path.normpath(os.path.join("C:/Program Files/Spice64/bin/ngspice.exe")),
-                os.path.normpath(os.path.join("C:/Program Files (x86)/ngspice/bin/ngspice.exe")),
-            ]
+        if self.system not in {"darwin", "linux", "windows"}:
+            raise RuntimeError(
+                f"Unsupported operating system for ngspice: {self.system}. EngiBench supports Windows, macOS, and Linux."
+            )
 
-            ngspice_path: str | None = next((p for p in possible_paths if p and os.path.exists(p)), None)
-            if ngspice_path is None:
-                raise FileNotFoundError(
-                    "ngspice.exe not found. You can install it via Chocolatey "
-                    "(`choco install ngspice`) or download it from "
-                    "https://sourceforge.net/projects/ngspice/files/ng-spice-rework/. "
-                    "You can also see our GitHub Actions workflow (test.yml) for how to automatically install it."
-                )
-            return ngspice_path
-        if self.system in ["darwin", "linux"]:
-            # For MacOS and Linux, use system-installed ngspice
-            try:
-                # Check if ngspice is installed
-                subprocess.run(["ngspice", "--version"], capture_output=True, check=True)
-            except (subprocess.CalledProcessError, FileNotFoundError):
-                raise RuntimeError(
-                    "ngspice is not installed on your system. "
-                    "Please install it using your package manager:\n"
-                    "  - MacOS: brew install ngspice\n"
-                    "  - Linux: sudo apt-get install ngspice"
-                ) from None
-            return "ngspice"
-        raise RuntimeError(
-            f"Unsupported operating system for ngspice: {self.system}, we only support Windows, MacOS and Linux."
+        if self.configured_path:
+            path = os.path.abspath(os.path.expanduser(self.configured_path))
+            if not os.path.isfile(path):
+                raise FileNotFoundError(f"Configured ngspice executable does not exist: {path}")
+            return path
+
+        path_from_env = shutil.which("ngspice")
+        if path_from_env:
+            return path_from_env
+
+        if self.system == "windows":
+            common_paths = (
+                "C:/Program Files/Spice64/bin/ngspice.exe",
+                "C:/Program Files (x86)/ngspice/bin/ngspice.exe",
+            )
+            installed_path = next((os.path.normpath(path) for path in common_paths if os.path.isfile(path)), None)
+            if installed_path:
+                return installed_path
+
+        raise FileNotFoundError(
+            f"ngspice was not found. Set {NGSPICE_PATH_ENV} to a supported ngspice executable "
+            "or add it to PATH. See engibench/problems/power_electronics/README.md for installation instructions."
         )
 
     def run(self, netlist_path: str, log_file_path: str, timeout: int = 30) -> None:
@@ -97,6 +101,11 @@ class NgSpice:
             raise
 
     @property
+    def executable_path(self) -> str:
+        """Return the resolved ngspice executable path."""
+        return self._ngspice_path
+
+    @property
     def version(self) -> int:
         """Get the version of ngspice.
 
@@ -126,8 +135,6 @@ class NgSpice:
         cmd = [self._ngspice_path, "--version"]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
-        # Extract version number from second line of output and get only the major version
-
         # Example output:
         # ******
         # ** ngspice-44.2 : Circuit level simulation program
@@ -138,8 +145,11 @@ class NgSpice:
         # ** Please get your ngspice manual from https://ngspice.sourceforge.io/docs.html
         # ** Please file your bug-reports at http://ngspice.sourceforge.net/bugrep.html
         # ******
-        full_version = result.stdout.splitlines()[1].split()[1].split("-")[1]
-        return int(full_version.split(".")[0])  # Return only the major version
+        output = f"{result.stdout}\n{result.stderr}"
+        match = re.search(r"\bngspice-(\d+)(?:\.\d+)*\b", output, flags=re.IGNORECASE)
+        if match is None:
+            raise RuntimeError(f"Could not determine ngspice version from: {output.strip()!r}")
+        return int(match.group(1))
 
 
 class NgSpiceManualNotFoundError(FileNotFoundError):

--- a/engibench/problems/power_electronics/utils/ngspice.py
+++ b/engibench/problems/power_electronics/utils/ngspice.py
@@ -5,6 +5,7 @@ import platform
 import re
 import shutil
 import subprocess
+import warnings
 
 MIN_SUPPORTED_VERSION: int = 42  # Major version number of ngspice
 MAX_SUPPORTED_VERSION: int = 45  # Major version number of ngspice
@@ -27,6 +28,13 @@ class NgSpice:
                 Takes precedence over ``NGSPICE_PATH`` and ``PATH``.
             ngspice_windows_path: Deprecated alias for ``ngspice_path``.
         """
+        if ngspice_windows_path is not None:
+            warnings.warn(
+                "ngspice_windows_path is deprecated; use ngspice_path instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if ngspice_path is not None and ngspice_windows_path is not None:
             raise ValueError("Pass either ngspice_path or ngspice_windows_path, not both.")
 

--- a/engibench/problems/power_electronics/v0.py
+++ b/engibench/problems/power_electronics/v0.py
@@ -78,7 +78,8 @@ class PowerElectronics(Problem[npt.NDArray]):
             original_netlist_path: The path to the original netlist file. Accepts both relative and absolute paths.
             bucket_id: The bucket ID for the netlist file. E.g. "5_4_3_6_10".
             mode: The mode for the simulation. Default to "control". mode = "batch" is for development.
-            ngspice_path: The path to the ngspice executable for Windows.
+            ngspice_path: Optional path to the ngspice executable. When omitted,
+                ``NGSPICE_PATH`` and then ``PATH`` are used.
         """
         super().__init__(seed=seed)
 
@@ -110,7 +111,7 @@ class PowerElectronics(Problem[npt.NDArray]):
         self.config = process_sweep_data(config=self.config, sweep_data=design.tolist())
         rewrite_netlist(self.config, rewrite_netlist_str, edge_map)
         # Use the ngspice wrapper to run the simulation
-        ngspice = NgSpice(ngspice_windows_path=self.ngspice_path)
+        ngspice = NgSpice(ngspice_path=self.ngspice_path)
         ngspice.run(self.config.rewrite_netlist_path, self.config.log_file_path)
         DcGain, VoltageRipple = process_log_file(self.config.log_file_path)
         return SimulationResult(np.array([DcGain, VoltageRipple]))

--- a/scripts/install_ngspice_macos.sh
+++ b/scripts/install_ngspice_macos.sh
@@ -6,11 +6,31 @@ readonly VERSION="44.2"
 readonly SHA256="e7dadfb7bd5474fd22409c1e5a67acdec19f77e597df68e17c5549bc1390d7fd"
 readonly URL="https://sourceforge.net/projects/ngspice/files/ng-spice-rework/old-releases/${VERSION}/ngspice-${VERSION}.tar.gz/download"
 readonly PREFIX="${1:-${HOME}/.local/ngspice-${VERSION}}"
+readonly EXECUTABLE="${PREFIX}/bin/ngspice"
 
-if [[ -x "${PREFIX}/bin/ngspice" ]] && "${PREFIX}/bin/ngspice" --version 2>&1 | grep -q "ngspice-${VERSION}"; then
+if [[ -x "${EXECUTABLE}" ]] \
+    && lipo -archs "${EXECUTABLE}" | grep -qw "x86_64" \
+    && "${EXECUTABLE}" --version 2>&1 | grep -q "ngspice-${VERSION}"; then
     echo "ngspice ${VERSION} is already installed at ${PREFIX}"
     exit 0
 fi
+
+build_command=()
+case "$(uname -m)" in
+    arm64)
+        if ! arch -x86_64 /usr/bin/true 2>/dev/null; then
+            echo "Rosetta 2 is required to build the validated x86_64 ngspice binary." >&2
+            echo "Install it with: softwareupdate --install-rosetta --agree-to-license" >&2
+            exit 1
+        fi
+        build_command=(arch -x86_64)
+        ;;
+    x86_64) ;;
+    *)
+        echo "Unsupported macOS architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
 
 work_dir="$(mktemp -d)"
 trap 'rm -rf "${work_dir}"' EXIT
@@ -21,14 +41,14 @@ echo "${SHA256}  ${archive}" | shasum -a 256 --check
 tar -xzf "${archive}" -C "${work_dir}"
 
 cd "${work_dir}/ngspice-${VERSION}"
-CXXFLAGS="-Wno-invalid-specialization" ./configure \
+CXXFLAGS="-Wno-invalid-specialization" "${build_command[@]}" ./configure \
     --prefix="${PREFIX}" \
     --enable-relpath \
     --without-x \
     --with-readline=no \
     --with-fftw3=no \
     --disable-openmp
-make -j2 CXXFLAGS="-Wno-invalid-specialization"
-make install CXXFLAGS="-Wno-invalid-specialization"
+"${build_command[@]}" make -j2 CXXFLAGS="-Wno-invalid-specialization"
+"${build_command[@]}" make install CXXFLAGS="-Wno-invalid-specialization"
 
-"${PREFIX}/bin/ngspice" --version
+"${EXECUTABLE}" --version

--- a/scripts/install_ngspice_macos.sh
+++ b/scripts/install_ngspice_macos.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly VERSION="44.2"
+readonly SHA256="e7dadfb7bd5474fd22409c1e5a67acdec19f77e597df68e17c5549bc1390d7fd"
+readonly URL="https://sourceforge.net/projects/ngspice/files/ng-spice-rework/old-releases/${VERSION}/ngspice-${VERSION}.tar.gz/download"
+readonly PREFIX="${1:-${HOME}/.local/ngspice-${VERSION}}"
+
+if [[ -x "${PREFIX}/bin/ngspice" ]] && "${PREFIX}/bin/ngspice" --version 2>&1 | grep -q "ngspice-${VERSION}"; then
+    echo "ngspice ${VERSION} is already installed at ${PREFIX}"
+    exit 0
+fi
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+archive="${work_dir}/ngspice-${VERSION}.tar.gz"
+curl --fail --location --retry 3 --output "${archive}" "${URL}"
+echo "${SHA256}  ${archive}" | shasum -a 256 --check
+tar -xzf "${archive}" -C "${work_dir}"
+
+cd "${work_dir}/ngspice-${VERSION}"
+CXXFLAGS="-Wno-invalid-specialization" ./configure \
+    --prefix="${PREFIX}" \
+    --enable-relpath \
+    --without-x \
+    --with-readline=no \
+    --with-fftw3=no \
+    --disable-openmp
+make -j2 CXXFLAGS="-Wno-invalid-specialization"
+make install CXXFLAGS="-Wno-invalid-specialization"
+
+"${PREFIX}/bin/ngspice" --version

--- a/scripts/install_ngspice_macos.sh
+++ b/scripts/install_ngspice_macos.sh
@@ -51,4 +51,9 @@ CXXFLAGS="-Wno-invalid-specialization" "${build_command[@]}" ./configure \
 "${build_command[@]}" make -j2 CXXFLAGS="-Wno-invalid-specialization"
 "${build_command[@]}" make install CXXFLAGS="-Wno-invalid-specialization"
 
+if ! lipo -archs "${EXECUTABLE}" | grep -qw "x86_64"; then
+    echo "Expected an x86_64 ngspice executable at ${EXECUTABLE}." >&2
+    exit 1
+fi
+
 "${EXECUTABLE}" --version

--- a/scripts/install_ngspice_macos.sh
+++ b/scripts/install_ngspice_macos.sh
@@ -15,7 +15,7 @@ if [[ -x "${EXECUTABLE}" ]] \
     exit 0
 fi
 
-build_command=()
+build_command=(/usr/bin/env)
 case "$(uname -m)" in
     arm64)
         if ! arch -x86_64 /usr/bin/true 2>/dev/null; then

--- a/tests/test_ngspice.py
+++ b/tests/test_ngspice.py
@@ -1,0 +1,93 @@
+"""Tests for locating and validating the ngspice executable."""
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from engibench.problems.power_electronics.utils import ngspice as ngspice_module
+from engibench.problems.power_electronics.utils.ngspice import MAX_SUPPORTED_VERSION
+from engibench.problems.power_electronics.utils.ngspice import NgSpice
+
+VERSION_OUTPUT = "******\n** ngspice-44.2 : Circuit level simulation program\n******\n"
+
+
+def mock_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every ngspice version probe report the supported CI version."""
+
+    def run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=VERSION_OUTPUT, stderr="")
+
+    monkeypatch.setattr(ngspice_module.subprocess, "run", run)
+
+
+def executable(tmp_path: Path, name: str = "ngspice") -> Path:
+    """Create a file suitable for path-resolution tests."""
+    path = tmp_path / name
+    path.write_text("test executable")
+    return path
+
+
+def test_explicit_path_takes_precedence(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The constructor argument must override the environment and PATH."""
+    explicit = executable(tmp_path, "explicit-ngspice")
+    monkeypatch.setenv("NGSPICE_PATH", str(tmp_path / "environment-ngspice"))
+    monkeypatch.setattr(ngspice_module.platform, "system", lambda: "Darwin")
+    mock_version(monkeypatch)
+
+    assert NgSpice(ngspice_path=str(explicit)).executable_path == str(explicit)
+
+
+def test_legacy_windows_path_keyword_is_supported(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep the previous public keyword working for existing callers."""
+    configured = executable(tmp_path)
+    monkeypatch.setattr(ngspice_module.platform, "system", lambda: "Windows")
+    mock_version(monkeypatch)
+
+    assert NgSpice(ngspice_windows_path=str(configured)).executable_path == str(configured)
+
+
+def test_environment_path_works_on_macos(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """NGSPICE_PATH must work outside Windows, which is the issue #249 use case."""
+    configured = executable(tmp_path)
+    monkeypatch.setenv("NGSPICE_PATH", str(configured))
+    monkeypatch.setattr(ngspice_module.platform, "system", lambda: "Darwin")
+    mock_version(monkeypatch)
+
+    assert NgSpice().executable_path == str(configured)
+
+
+def test_path_lookup_is_cross_platform(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Without an override, use the ngspice executable found on PATH."""
+    discovered = executable(tmp_path)
+    monkeypatch.delenv("NGSPICE_PATH", raising=False)
+    monkeypatch.setattr(ngspice_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(ngspice_module.shutil, "which", lambda _name: str(discovered))
+    mock_version(monkeypatch)
+
+    assert NgSpice().executable_path == str(discovered)
+
+
+def test_invalid_configured_path_fails_clearly(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Do not silently ignore a bad path selected by the user or CI."""
+    missing = tmp_path / "missing-ngspice"
+    monkeypatch.setenv("NGSPICE_PATH", str(missing))
+    monkeypatch.setattr(ngspice_module.platform, "system", lambda: "Darwin")
+
+    with pytest.raises(FileNotFoundError, match="Configured ngspice executable does not exist"):
+        NgSpice()
+
+
+def test_version_can_be_reported_on_stderr(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Some ngspice packages write their version banner to stderr."""
+    configured = executable(tmp_path)
+    monkeypatch.setattr(ngspice_module.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        ngspice_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr="ngspice-45.2 : Circuit level simulation program"
+        ),
+    )
+
+    assert NgSpice(ngspice_path=str(configured)).version == MAX_SUPPORTED_VERSION

--- a/tests/test_ngspice.py
+++ b/tests/test_ngspice.py
@@ -44,7 +44,8 @@ def test_legacy_windows_path_keyword_is_supported(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(ngspice_module.platform, "system", lambda: "Windows")
     mock_version(monkeypatch)
 
-    assert NgSpice(ngspice_windows_path=str(configured)).executable_path == str(configured)
+    with pytest.warns(DeprecationWarning, match="ngspice_windows_path is deprecated"):
+        assert NgSpice(ngspice_windows_path=str(configured)).executable_path == str(configured)
 
 
 def test_environment_path_works_on_macos(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_problem_implementations.py
+++ b/tests/test_problem_implementations.py
@@ -119,8 +119,6 @@ def test_python_problem_impl(
     """
     if problem_class.container_id is not None and not sys.platform.startswith("linux"):
         pytest.skip(f"Skipping containerized problem {problem_class.__name__} on non-linux platform")
-    if problem_class.__module__.startswith("engibench.problems.power_electronics") and sys.platform == "darwin":
-        pytest.skip(f"Skipping {problem_class.__name__} on MacOs")
     ref_path = Path(__file__).parent / "reference" / "simulate" / (problem_id(problem_class) + ".json")
     if RefCreationMode.from_env() == RefCreationMode.Missing and ref_path.is_file():
         pytest.skip("Reference values already exist. Skipping test.")


### PR DESCRIPTION
## Summary

Restore PowerElectronics simulations and reference testing on macOS.

Closes #249.

## Changes

- Add cross-platform `ngspice_path` and `NGSPICE_PATH` support.
- Preserve `ngspice_windows_path` as a deprecated alias.
- Add a macOS installer for checksum-verified ngspice 44.2.
- Build and verify the validated x86_64 executable on Intel and Apple Silicon Macs.
- Use Rosetta 2 for the x86_64 build on Apple Silicon.
- Run the macOS workflow on an explicit Intel runner and cache the ngspice build.
- Re-enable the PowerElectronics reference test on macOS.
- Document the macOS installation and architecture constraint.
- Add focused tests for executable discovery and version detection.

## Why x86_64?

The existing PowerElectronics reference values are reproduced by ngspice 44.2
x86_64. Native ARM64 simulations produce substantially different results for
the same EngiBench netlist.

Testing the latest ngspice release also showed that upgrading alone does not
resolve the difference:

| Configuration | Gain | Vpp ratio |
| --- | ---: | ---: |
| ngspice 44.2 x86_64 | -0.00809852 | -0.914900 |
| ngspice 46 x86_64 | -0.00819730 | -0.721989 |
| ngspice 46 ARM64 | 0.01072067 | 1.304891 |

Architecture-dependent transient results have also been reported upstream in
[ngspice bug #622](https://sourceforge.net/p/ngspice/bugs/622/). That report
concerns a different circuit, so it does not establish the cause of the
EngiBench discrepancy. It does document substantial AArch64 and x86_64
differences in a numerically sensitive simulation.

This PR therefore pins the simulator version and architecture used by the
existing benchmark instead of adding architecture-specific reference values.

## Validation

- Built and ran ngspice 44.2 x86_64 on an Apple Silicon Mac through Rosetta.
- Confirmed that the simulation matches the existing PowerElectronics reference tolerance.
- `pytest -q tests/test_ngspice.py`: 6 passed.
- Ruff passes for the changed Python modules and tests.
- Targeted mypy, shell syntax, and diff validation pass.

## Limitations

This change provides a reproducible backend for PowerElectronics v0. It does
not claim that native ARM64 ngspice produces equivalent results or establish
which numerical solution is physically more accurate.
