### PR TITLE
fix(photonics2d): honor lambda1/lambda2 passed per call

### DIFF
--- a/engibench/problems/photonics2d/v1.py
+++ b/engibench/problems/photonics2d/v1.py
@@ -57,6 +57,7 @@ from engibench.problems.photonics2d.backend import filter_and_project
 from engibench.problems.photonics2d.backend import insert_mode
 from engibench.problems.photonics2d.backend import mode_overlap
 from engibench.problems.photonics2d.backend import poly_ramp
+from engibench.problems.photonics2d.backend import wavelength_to_frequency
 from engibench.problems.photonics2d.v0 import Photonics2D as Photonics2D_v0
 
 
@@ -102,6 +103,17 @@ class Photonics2D(Photonics2D_v0):
         self.design_space = spaces.Box(low=0.0, high=1.0, shape=(self.num_elems_x, self.num_elems_y), dtype=np.float64)
 
     # ------------------------------------------------------------------ helpers
+
+    def _setup_simulation(self, config: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Set up the simulation and update the frequencies from ``lambda1`` / ``lambda2``.
+
+        v0 only computes ``omega1`` / ``omega2`` in ``__init__``, so wavelengths passed in ``config``
+        were ignored.
+        """
+        conditions = super()._setup_simulation(config)
+        self.omega1 = wavelength_to_frequency(conditions["lambda1"])
+        self.omega2 = wavelength_to_frequency(conditions["lambda2"])
+        return conditions
 
     def _check_design(self, design: npt.NDArray, config: dict[str, Any] | None) -> None:
         """Validate ``design`` (and any overridden config) against the declared constraints.

--- a/tests/test_photonics2d.py
+++ b/tests/test_photonics2d.py
@@ -12,6 +12,8 @@ as-is (no projection), and ``optimize`` returns the physical (projected) density
 These tests use a small grid and few optimization steps to stay fast.
 """
 
+import dataclasses
+
 import numpy as np
 import pytest
 
@@ -157,3 +159,25 @@ def test_design_to_epsr_is_linear_scaling(problem: Photonics2D) -> None:
     design_mask = problem._design_region.astype(bool)
     assert np.allclose(epsr_zeros[design_mask], problem._epsr_min)
     assert np.allclose(epsr_ones[design_mask], problem._epsr_max)
+
+
+# --------------------------------------------------------------------- conditions
+
+
+def test_simulate_honors_wavelengths_passed_per_call(problem: Photonics2D, start_design: np.ndarray) -> None:
+    """Wavelengths passed per call must give the same result as wavelengths passed to the constructor."""
+    wavelengths = {"lambda1": 0.7, "lambda2": 1.4}
+    built = Photonics2D(num_elems_x=NUM_X, num_elems_y=NUM_Y, config=wavelengths)
+    per_call = float(problem.simulate(start_design, config=wavelengths)[0])
+    at_construction = float(built.simulate(start_design)[0])
+    assert per_call == pytest.approx(at_construction, rel=1e-9)
+
+
+def test_dataset_row_reproduces_its_own_objective() -> None:
+    """Simulating a stored design under its own conditions returns the objective stored beside it."""
+    problem = Photonics2D()
+    for row in problem.dataset["test"].select(range(2)):
+        conditions = {f.name: row[f.name] for f in dataclasses.fields(Photonics2D.Conditions)}
+        design = np.asarray(row["optimal_design"], dtype=float)
+        got = float(problem.simulate(design, config=conditions)[0])
+        assert got == pytest.approx(row["total_overlap"], rel=1e-6)


### PR DESCRIPTION
Fixes #274.

`simulate(design, config={"lambda1": ..., "lambda2": ...})` ignored the wavelengths. The solver reads `self.omega1` / `self.omega2`, which v0 only computes in `__init__`; all other conditions are read from the dict `_setup_simulation` returns, which is why `config=` works for them.

v1 now overrides `_setup_simulation` to recompute both frequencies from the merged conditions. `simulate` and `optimize` both call it.

v0 is unchanged so that published v0 results stay reproducible.

## Verified

Simulating the first five test-set designs under their own conditions, with one problem instance and the conditions passed per call:

| row | stored objective | before | after |
|---|---|---|---|
| 0 | 4.7460 | 0.2199 | 4.7460 |
| 1 | 5.7242 | 1.0781 | 5.7242 |
| 2 | 6.0318 | 0.3333 | 6.0318 |
| 3 | 5.7660 | 1.9619 | 5.7660 |
| 4 | 5.9565 | 1.3911 | 5.9565 |

The same design at the default wavelengths still gives 0.2199, so the fix changes the result only when the wavelengths differ.

## Tests

- `test_simulate_honors_wavelengths_passed_per_call`: wavelengths passed per call give the same result as wavelengths passed to the constructor. Fails on main.
- `test_dataset_row_reproduces_its_own_objective`: simulating a dataset design under its own conditions returns the stored objective. This would be worth adding for the other problems too; `beams2d` passes it to within 1e-5.
