### PR TITLE
feat(beams2d): record the optimization trajectory on each OptiStep

### DIFF
--- a/engibench/problems/beams2d/v0.py
+++ b/engibench/problems/beams2d/v0.py
@@ -226,12 +226,9 @@ class Beams2D(Problem[npt.NDArray]):
             self.reset_called = True  # override for multiple reset calls in optimize
             c = self.simulate(xPrint, ce=ce, config=dataclasses.asdict(simulate_config))
 
-            # Record the current state in optisteps_history
-            current_step = ExtendedOptiStep(obj_values=np.array(c), step=loop)
-            current_step.design = np.array(xPrint)
-            optisteps_history.append(current_step)
-
-            loop += 1
+            # The design this step was evaluated at, taken before the overhang
+            # filter below rebinds xPrint to the next one.
+            design = np.array(xPrint)
 
             dc = (-base_config.penal * xPrint ** (base_config.penal - 1) * (self.__st.Emax - self.__st.Emin)) * ce
             dv = np.ones(base_config.nely * base_config.nelx)
@@ -252,6 +249,40 @@ class Beams2D(Problem[npt.NDArray]):
                 xnew.reshape(base_config.nelx * base_config.nely, 1) - x.reshape(base_config.nelx * base_config.nely, 1),
                 np.inf,
             )
+
+            # Record the current state in optisteps_history, now that the move
+            # this design led to is known.
+            #
+            # x_sensitivities is the filtered objective sensitivity alone, one
+            # value per design variable, so that it has the same shape as the
+            # design it belongs to. The volume sensitivity dv is deliberately not
+            # stacked alongside it: consumers flatten this field, so an extra
+            # channel doubles its length with nothing recording that it did, and
+            # photonics2d -- the other 2D problem that reports sensitivities --
+            # reports the objective gradient by itself.
+            #
+            # The move is measured in printed density, the space the recorded
+            # design is in, so that design + update is the next step's design;
+            # inner_opt also returns the raw density field, and differencing that
+            # instead would mix the two spaces. The objective delta needs the
+            # *next* step's objective, so it is filled in on the following pass,
+            # and the last step keeps None rather than costing an extra solve.
+            obj_values = np.array(c)
+            if optisteps_history:
+                previous = optisteps_history[-1]
+                previous.obj_values_update = obj_values - previous.obj_values
+            current_step = ExtendedOptiStep(
+                obj_values=obj_values,
+                step=loop,
+                x=design,
+                x_sensitivities=dc.copy(),
+                x_update=xPrint - design,
+            )
+            current_step.design = design
+            optisteps_history.append(current_step)
+
+            loop += 1
+
             x = deepcopy(xnew)
 
         return design_to_image(xPrint, base_config.nelx, base_config.nely), optisteps_history

--- a/engibench/problems/beams2d/v1.py
+++ b/engibench/problems/beams2d/v1.py
@@ -76,12 +76,9 @@ class Beams2D(Beams2D_v0):
             self.reset_called = True  # override for multiple reset calls in optimize
             c = self.simulate(xPrint, ce=ce, config=dataclasses.asdict(simulate_config))
 
-            # Record the current state in optisteps_history
-            current_step = ExtendedOptiStep(obj_values=np.array(c), step=loop)
-            current_step.design = np.array(xPrint)
-            optisteps_history.append(current_step)
-
-            loop += 1
+            # The design this step was evaluated at, taken before the overhang
+            # filter below rebinds xPrint to the next one.
+            design = np.array(xPrint)
 
             dc = (-base_config.penal * xPrint ** (base_config.penal - 1) * (self.__st.Emax - self.__st.Emin)) * ce
             dv = np.ones(base_config.nely * base_config.nelx)
@@ -102,6 +99,40 @@ class Beams2D(Beams2D_v0):
                 xnew.reshape(base_config.nelx * base_config.nely, 1) - x.reshape(base_config.nelx * base_config.nely, 1),
                 np.inf,
             )
+
+            # Record the current state in optisteps_history, now that the move
+            # this design led to is known.
+            #
+            # x_sensitivities is the filtered objective sensitivity alone, one
+            # value per design variable, so that it has the same shape as the
+            # design it belongs to. The volume sensitivity dv is deliberately not
+            # stacked alongside it: consumers flatten this field, so an extra
+            # channel doubles its length with nothing recording that it did, and
+            # photonics2d -- the other 2D problem that reports sensitivities --
+            # reports the objective gradient by itself.
+            #
+            # The move is measured in printed density, the space the recorded
+            # design is in, so that design + update is the next step's design;
+            # inner_opt also returns the raw density field, and differencing that
+            # instead would mix the two spaces. The objective delta needs the
+            # *next* step's objective, so it is filled in on the following pass,
+            # and the last step keeps None rather than costing an extra solve.
+            obj_values = np.array(c)
+            if optisteps_history:
+                previous = optisteps_history[-1]
+                previous.obj_values_update = obj_values - previous.obj_values
+            current_step = ExtendedOptiStep(
+                obj_values=obj_values,
+                step=loop,
+                x=design,
+                x_sensitivities=dc.copy(),
+                x_update=xPrint - design,
+            )
+            current_step.design = design
+            optisteps_history.append(current_step)
+
+            loop += 1
+
             x = deepcopy(xnew)
 
         return design_to_image(xPrint, base_config.nelx, base_config.nely), optisteps_history

--- a/tests/test_beams2d.py
+++ b/tests/test_beams2d.py
@@ -1,0 +1,79 @@
+"""Tests for the Beams2D problem.
+
+`optimize` records, for every step, the design it was evaluated at, the filtered
+sensitivities there, and the move the optimizer made from it. These tests pin each
+field to the step it belongs to.
+
+A small grid and few iterations keep this fast.
+"""
+
+from itertools import pairwise
+
+import numpy as np
+import pytest
+
+from engibench.problems.beams2d import Beams2D
+
+NELX = 20
+NELY = 10
+MAX_ITER = 4
+VOLFRAC = 0.5
+N_ELEMS = NELX * NELY
+
+
+@pytest.fixture(scope="module")
+def problem() -> Beams2D:
+    return Beams2D(seed=0, config={"nelx": NELX, "nely": NELY, "volfrac": VOLFRAC})
+
+
+@pytest.fixture(scope="module")
+def optimized(problem: Beams2D) -> tuple[np.ndarray, list]:
+    """Run optimize once and reuse across tests (the expensive step)."""
+    problem.reset(seed=0)
+    start = np.full(problem.design_space.shape, VOLFRAC, dtype=np.float64)
+    # max_iter goes through optimize rather than the constructor: it lives on
+    # Config, not SimulateConfig, so optimize rebuilds it from the default.
+    return problem.optimize(start, config={"max_iter": MAX_ITER})
+
+
+def test_history_is_numbered_from_zero(optimized: tuple) -> None:
+    _opt, history = optimized
+    assert 1 <= len(history) <= MAX_ITER
+    assert [step.step for step in history] == list(range(len(history)))
+
+
+def test_every_step_records_design_sensitivities_and_update(optimized: tuple) -> None:
+    _opt, history = optimized
+    for step in history:
+        assert step.design.shape == (N_ELEMS,)
+        # `x` is the core field every generic consumer reads; `design` is kept
+        # for the callers that already use it.
+        assert step.x is step.design
+        # One sensitivity per design variable, so it is shaped like the design.
+        assert step.x_sensitivities.shape == step.x.shape
+        assert step.x_update.shape == (N_ELEMS,)
+
+
+def test_sensitivities_are_nonpositive(optimized: tuple) -> None:
+    """Compliance falls as material is added, and the optimizer clips dc at zero."""
+    _opt, history = optimized
+    for step in history:
+        assert np.all(step.x_sensitivities <= 0.0)
+        assert np.all(np.isfinite(step.x_sensitivities))
+
+
+def test_update_is_the_move_to_the_next_design(optimized: tuple) -> None:
+    """x_update is the step the optimizer took, so it lands on the next design."""
+    _opt, history = optimized
+    for step, following in pairwise(history):
+        np.testing.assert_allclose(step.x + step.x_update, following.x, atol=1e-12)
+
+
+def test_objective_delta_is_filled_in_except_on_the_last_step(optimized: tuple) -> None:
+    """A step's delta needs the next step's objective, so the last one has none."""
+    _opt, history = optimized
+    if len(history) < 2:  # noqa: PLR2004 - a single step has no delta to check
+        pytest.skip("optimization converged in one step")
+    for step, following in pairwise(history):
+        np.testing.assert_allclose(step.obj_values_update, following.obj_values - step.obj_values)
+    assert history[-1].obj_values_update is None


### PR DESCRIPTION
## What

`beams2d` recorded only the objective value and the design at each optimization
step. The sensitivity at that design, the move the optimizer made from it, and the
objective change that move produced were all computed and thrown away, so
recovering any of them afterwards meant re-running the solve that had already
produced them.

Each step now carries what the optimizer already knew:

| field | value |
|---|---|
| `x` | the design the step was evaluated at |
| `x_sensitivities` | the filtered objective sensitivity there |
| `x_update` | the move taken from that design |
| `obj_values_update` | the objective change that move produced |

Nothing new is computed — every value already existed in the loop. The step is
recorded after `inner_opt` rather than before the sensitivity block, because the
move is not known until then, and the design is taken beforehand because the
overhang filter rebinds `xPrint`.

`ExtendedOptiStep` and its `design` field are untouched. `x` holds the same array,
so callers reading either one keep working.

## Three choices worth a reviewer's attention

**`x_sensitivities` is the objective sensitivity alone, shaped like the design.**
One value per design variable. `thermoelastic2d` and `beams3d` stack theirs as
`[objective..., constraint]` on a leading axis; `photonics2d` reports the objective
gradient bare. The bare form is used here because downstream consumers flatten this
field — EngiOpt's collector does `np.ravel(...)` per step — so an extra channel
doubles the vector's length with nothing recording that it did, and a reader
assuming one sensitivity per design variable would misread it silently. The volume
sensitivity `dv` is one line to add back if that is wanted.

**`x_update` is in printed-density space.** `inner_opt` returns three fields — raw
density variables, processed density, printed density — and the recorded design is
the printed one. Differencing the raw field would mix the two spaces, so the move
is measured against the printed one, making `design + x_update` exactly the next
step's design. There is a test for that.

**The last step's `obj_values_update` stays `None`.** `thermoelastic2d` fills its
own in by running an extra iteration after convergence and then reverting the
design. That buys one scalar for the price of a full solve, and the value is
derivable from the next step for every step that has one. On `beams2d` the revert
would also put the returned design at risk, since `xPrint` is rebound three times
per iteration.

## Effect on existing behavior

None. Running `optimize` for 25 iterations on a 20x10 grid, with and without the
overhang constraint, before and after:

| | `main` vs branch |
|---|---|
| step count | identical |
| objective values | identical |
| per-step designs | identical |
| returned design | identical |

## Tests

`tests/test_beams2d.py` is new, following `tests/test_photonics2d.py` (module-scoped
fixture, small grid, few iterations; about a second to run). It checks step
numbering, that each recorded field is shaped like the design, that the sensitivity
is nonpositive and finite, that `design + x_update` lands on the next step's design,
and that `obj_values_update` matches the next step's objective difference on every
step but the last.

If you add tests here: `max_iter` must be passed to `optimize`, not to the
constructor. `optimize` rebuilds its config as
`Config(**{**asdict(self.simulate_config), **config})`, and `SimulateConfig` does not
carry `max_iter`, so a constructor-supplied value is silently replaced by the default
of 100.

## Follow-ups this does not attempt

`OptiStep.x_sensitivities` is documented only as "the sensitivities of the design
variables". Across the problems that populate it, the layout varies — bare grid
(`photonics2d`) against channel-first stacks of differing depth (`thermoelastic2d` 4,
`beams3d` 2), with the channel order recorded nowhere and no relation to
`problem.objectives`. A metric written against this field cannot currently be
problem-agnostic. Worth a documented convention in `core.py`, separately from this PR.

`heatconduction2d` builds its history by regex-scraping an IPOPT log after a
dolfin-adjoint container run, with no per-iteration callback holding the design; it
needs a `derivative_cb_post` on the `ReducedFunctional` and new arrays in the output
npz. `mto2d` parses solver output columns that contain no gradient.

This changes what `optimize()` returns at runtime and touches no published dataset.
Dataset generation keeps the *returned* design and discards the history — see
`photonics2d/dataset_slurm_test.py`, where it is bound to `_obj_trajectory` — so
trajectories reach a dataset only if a generation script is changed to keep them.