### PR TITLE
fix(heatconduction): keep the FEniCS JIT cache on the host

### DIFF
--- a/engibench/problems/heatconduction2d/shared.py
+++ b/engibench/problems/heatconduction2d/shared.py
@@ -27,6 +27,10 @@ def run_container_script(
     shutil.copy(cli_module_path, "templates/engibench/utils")
     shutil.copy(script, "templates/")
 
+    # Keep the FEniCS JIT cache on the host, otherwise every container run recompiles all forms.
+    jit_cache = Path(os.environ.get("SCRATCH") or Path.home(), ".cache", "engibench", "dijitso")
+    jit_cache.mkdir(parents=True, exist_ok=True)
+
     container.run(
         command=[
             "python3",
@@ -39,7 +43,9 @@ def run_container_script(
         mounts=[
             (os.getcwd(), "/home/fenics/shared"),
             (cli_module_path, "/home/fenics/shared/templates/engibench/utils/cli.py"),
+            (str(jit_cache), "/home/fenics/.cache/dijitso"),
         ],
+        env={"DIJITSO_CACHE_DIR": "/home/fenics/.cache/dijitso"},
         stdin=stdin,
     )
     return output_path

--- a/tests/test_heatconduction.py
+++ b/tests/test_heatconduction.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from engibench.problems.heatconduction2d import shared
+from engibench.utils import container
+
+
+def test_run_container_script_mounts_jit_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(container, "run", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setenv("SCRATCH", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    shared.run_container_script("image", Path(shared.__file__), (), "out.txt")
+
+    jit_cache = tmp_path / ".cache" / "engibench" / "dijitso"
+    assert jit_cache.is_dir()
+    assert (str(jit_cache), "/home/fenics/.cache/dijitso") in calls[0]["mounts"]
+    assert calls[0]["env"] == {"DIJITSO_CACHE_DIR": "/home/fenics/.cache/dijitso"}


### PR DESCRIPTION
Fixes #273.

Every `simulate` and `optimize` of the heat conduction problems starts a new container. FEniCS compiles its forms on first use and caches the result, but the cache is inside the container, so it is lost when the call ends and the next call compiles everything again. In the sweep behind #273 that was about 18 compilations per call, against 0.35 s of actual solver time.

Fix: mount a host directory into the container and point `DIJITSO_CACHE_DIR` at it. The directory is `$SCRATCH/.cache/engibench/dijitso` if `SCRATCH` is set, otherwise `~/.cache/engibench/dijitso`. Delete it to reset the cache.

Both heat problems go through `run_container_script`, and the mount and environment variable go through the existing `mounts=` / `env=` arguments of `container.run`, so this is the same for Docker, Podman and Apptainer.

## Verified

Docker (macOS): a script that assembles one form takes 7.4 s cold and 1.1 s warm. Three containers started at once on an empty cache all succeed and leave exactly one copy of each compiled module. dijitso is written for this: it compiles to a temp file and moves it into the cache with an atomic rename.

Apptainer (Euler): three back-to-back `simulate` calls take 19 s, 5 s, 5 s. A 50-design package went from ~57 min to ~12 min with the same results.

`DIJITSO_CACHE_DIR` is the only variable dijitso reads; `INSTANT_CACHE_DIR` from the issue's workaround is ignored by this FEniCS version.

## Not in this PR

`run_container_script` names every container `dolfin`, so two heat conduction jobs on one Docker or Podman host fail with a name conflict. Apptainer ignores the name. That is an existing bug, not touched here.
